### PR TITLE
Add environment variable for supplier contracts bucket (#803)

### DIFF
--- a/charts-external/spark/templates/spark-configmap.yaml
+++ b/charts-external/spark/templates/spark-configmap.yaml
@@ -61,5 +61,7 @@ data:
   {{ end }}
 
   # SUPPLIER CONTRACT FILES
-  SPARK_SUPPLIER_CONTRACTS_BUCKET: {{ .Values.suppliers.bucket | quote }}
+  {{ if .Values.suppliersBucket }}
+  SPARK_SUPPLIER_CONTRACTS_BUCKET: {{ .Values.suppliersBucket | quote }}
+  {{ end }}
 {{ end }}

--- a/charts-external/spark/templates/spark-configmap.yaml
+++ b/charts-external/spark/templates/spark-configmap.yaml
@@ -59,4 +59,7 @@ data:
   {{ if .Values.volunteersBaseUrl }}
   VOLUNTEERS_BASE_URL: {{ .Values.volunteersBaseUrl | quote }}
   {{ end }}
+
+  # SUPPLIER CONTRACT FILES
+  SPARK_SUPPLIER_CONTRACTS_BUCKET: {{ .Values.suppliers.bucket | quote }}
 {{ end }}

--- a/environments/production/values.yaml
+++ b/environments/production/values.yaml
@@ -121,3 +121,6 @@ chatops:
 camps-index:
   enabled: true
   sparkAppSecretName: sparkdb-app
+
+suppliers:
+  bucket: midburn-spark-supplier-files-prod

--- a/environments/production/values.yaml
+++ b/environments/production/values.yaml
@@ -122,5 +122,4 @@ camps-index:
   enabled: true
   sparkAppSecretName: sparkdb-app
 
-suppliers:
-  bucket: midburn-spark-supplier-files-prod
+suppliersBucket: midburn-spark-supplier-files-prod

--- a/environments/production/values.yaml
+++ b/environments/production/values.yaml
@@ -81,6 +81,9 @@ spark:
   # Volunteers
   volunteersBaseUrl: https://volunteers.spark.midburn.org
 
+  # Supplier contract files
+  suppliersBucket: midburn-spark-supplier-files-prod
+
 nginx:
   htpasswdSecretName: nginx-htpasswd
 
@@ -122,4 +125,3 @@ camps-index:
   enabled: true
   sparkAppSecretName: sparkdb-app
 
-suppliersBucket: midburn-spark-supplier-files-prod

--- a/environments/staging/values.yaml
+++ b/environments/staging/values.yaml
@@ -122,5 +122,4 @@ camps-index:
   enabled: true
   sparkAppSecretName: sparkdb-app
 
-suppliers:
-  bucket: midburn-spark-supplier-files
+suppliersBucket: midburn-spark-supplier-files

--- a/environments/staging/values.yaml
+++ b/environments/staging/values.yaml
@@ -121,3 +121,6 @@ dreams:
 camps-index:
   enabled: true
   sparkAppSecretName: sparkdb-app
+
+suppliers:
+  bucket: midburn-spark-supplier-files

--- a/environments/staging/values.yaml
+++ b/environments/staging/values.yaml
@@ -86,6 +86,8 @@ spark:
   # Volunteers
   volunteersBaseUrl: https://volunteers.staging.midburn.org
 
+  # Supplier contract files
+    suppliersBucket: midburn-spark-supplier-files
 nginx:
   htpasswdSecretName: nginx-htpasswd
 
@@ -121,5 +123,3 @@ dreams:
 camps-index:
   enabled: true
   sparkAppSecretName: sparkdb-app
-
-suppliersBucket: midburn-spark-supplier-files


### PR DESCRIPTION
I have created the buckets midburn-spark-supplier-files and midburn-spark-supplier-files-prod
The are accessible by the same aws user, spark, that is currently configured on production.
